### PR TITLE
Añadido archivos .form a gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ bin
 *.jar
 .metadata
 *.properties
+*.form
 /binTest/


### PR DESCRIPTION
Se añaden archivos .form a .gitignore para que git no los rastree. Estos archivos son solo de utilidad para netbeans.